### PR TITLE
fix: bump kotlin version

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -61,7 +61,7 @@
       <preference name="GradlePluginGoogleServicesVersion" value="4.3.8" />
 
       <preference name="GradlePluginKotlinEnabled" value="true" />
-      <preference name="GradlePluginKotlinVersion" value="1.5.20" />
+      <preference name="GradlePluginKotlinVersion" value="1.7.10" />
     </config-file>
 
     <preference name="ANDROIDX_CORE_VERSION" default="1.6.+"/>


### PR DESCRIPTION
Fixes build problems related to Kotlin binary versions being incompatible.
Refer to https://github.com/havesource/cordova-plugin-push/pull/224